### PR TITLE
Symbolic Keys With :fast_hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,22 @@ Or install it yourself as:
 
     $ gem install rlaunchpadlib
 
-## Usag
+## Usage
 
-eTODO: Write usage instructions here
+```ruby
+person = Rlaunchpadlib::Person.new 'lazypower'
+puts person.date_created
+person.profile.inspect
+```
+
+You can optionally provide the fast_hash option which ensures that the keys to the Hash objects 
+are symbols instead of strings.
+
+```ruby
+person = Rlaunchpadlib::Person.new 'lazypower', {:fast_hash => true}
+puts person.date_created
+person.profile.inspect
+```
 
 ## Caveats
 

--- a/lib/rlaunchpadlib/client.rb
+++ b/lib/rlaunchpadlib/client.rb
@@ -7,20 +7,52 @@ module Rlaunchpadlib
 
         attr_accessor :base_uri
         attr_accessor :api_version
+        attr_accessor :opts
 
-        def initialize()
+        def initialize(options = {})
             @base_uri = "https://api.launchpad.net"
             @api_version = "1.0"
+            @opts = options
         end
 
         def get(scope, operation="")
+            result = nil
+            
             if operation.empty?
                 result = self.class.get "#{@base_uri}/#{@api_version}/#{scope}"
-                result.to_hash()
             else
                 result = self.class.get "#{@base_uri}/#{@api_version}/#{scope}/?ws.op=#{operation}"
+            end
+            
+            if fast_hash?
+                symbolize_keys result.to_hash()
+            else
                 result.to_hash()
             end
         end
+
+        private
+            # Compliments of Nico Ritsche & Samson Ootoovak
+            # 
+            # https://gist.github.com/ncri/5661189
+            def symbolize_keys(hash)
+                hash.inject({}){|result, (key, value)|
+                    new_key = case key
+                        when String then key.to_sym
+                        else key
+                    end
+                    new_value = case value
+                        when Hash then symbolize_keys(value)
+                        when Array then value.map{ |v| v.is_a?(Hash) ? symbolize_keys(v) : v }
+                        else value
+                    end
+                    result[new_key] = new_value
+                    result
+                }
+            end
+            
+            def fast_hash?
+                @opts.has_key?(:fast_hash) ? @opts[:fast_hash] : false
+            end
     end
 end

--- a/lib/rlaunchpadlib/person.rb
+++ b/lib/rlaunchpadlib/person.rb
@@ -1,6 +1,5 @@
 require 'httparty'
 
-
 module Rlaunchpadlib
 
     ##
@@ -9,6 +8,11 @@ module Rlaunchpadlib
     # https://launchpad.net/+apidoc/1.0.html#person
     #
     # Provides READ ONLY access
+    # 
+    # bewitchingme: Added an option to ensure the resulting hash uses symbols for keys;
+    # default behavior remains the same.
+    # 
+    # Person.new 'username', {:fast_hash => true}
     class Person
 
         attr_accessor :username
@@ -19,9 +23,11 @@ module Rlaunchpadlib
         attr_accessor :merge_proposals_data
         attr_accessor :requested_reviews_data
         attr_accessor :bugs_data
-
-        def initialize(username)
-            @client = Rlaunchpadlib::Client.new
+        attr_accessor :opts
+        
+        def initialize(username, options = {})
+            @opts = options
+            @client = Rlaunchpadlib::Client.new @opts
             @username = "~#{username}"
         end
 
@@ -33,7 +39,7 @@ module Rlaunchpadlib
         end
 
         def archive_subscriptions
-            if @archive_subscriptions_data.nil?                
+            if @archive_subscriptions_data.nil?
                 @archive_subscriptions_data =  @client.get(@username, 'getArchiveSubscriptionUrls')
             end
             @archive_subscriptions_data
@@ -84,13 +90,11 @@ module Rlaunchpadlib
             @bugs_data = nil
         end
 
-
         # I'm nuts so lets patch method missing for easy acces to 
         # profile data.
         def method_missing(name, *args, &block)
-          profile.has_key?(name.to_s) ? profile[name.to_s] : super
+          key = @opts[:fast_hash] ? name : name.to_s
+          profile.has_key?(key) ? profile[key] : super
         end
-
-
     end
 end

--- a/lib/rlaunchpadlib/project.rb
+++ b/lib/rlaunchpadlib/project.rb
@@ -3,7 +3,7 @@ module Rlaunchpadlib
   # bewitchingme: Added an option to ensure the resulting hash uses symbols for keys;
   # default behavior remains the same.
   # 
-  # Person.new 'username', {:fast_hash => true}
+  # Rlaunchpadlib::Project.new 'project', {:fast_hash => true}
   class Project
 
         attr_accessor :project

--- a/lib/rlaunchpadlib/project.rb
+++ b/lib/rlaunchpadlib/project.rb
@@ -1,5 +1,10 @@
 module Rlaunchpadlib
-    class Project
+  # 
+  # bewitchingme: Added an option to ensure the resulting hash uses symbols for keys;
+  # default behavior remains the same.
+  # 
+  # Person.new 'username', {:fast_hash => true}
+  class Project
 
         attr_accessor :project
         attr_accessor :overview_data
@@ -9,18 +14,19 @@ module Rlaunchpadlib
         attr_accessor :merge_proposal_data
         attr_accessor :subscription_data
         attr_accessor :timeline_data
+        attr_accessor :opts
 
-        def initialize(project)
+        def initialize(project, options = {})
+            @opts = options
             @project = project
-            @client = Rlaunchpadlib::Client.new
+            @client = Rlaunchpadlib::Client.new @opts
         end
 
         def overview
             if @overview_data.nil?
-                @client.get(@project)
-            else
-                @overview_data
+                @overview_data = @client.get(@project)
             end
+            @overview_data
         end
 
 
@@ -71,11 +77,10 @@ module Rlaunchpadlib
             @timeline_data = nil
         end
 
-
-
         # I'm nuts so lets patch method missing.
         def method_missing(name, *args, &block)
-          overview.has_key?(name.to_s) ? overview[name.to_s] : super
+          key = @opts[:fast_hash] ? name : name.to_s
+          overview.has_key?(key) ? overview[key] : super
         end
     end
 end

--- a/lib/rlaunchpadlib/project_group.rb
+++ b/lib/rlaunchpadlib/project_group.rb
@@ -5,7 +5,7 @@ module Rlaunchpadlib
   # bewitchingme: Added an option to ensure the resulting hash uses symbols for keys;
   # default behavior remains the same.
   # 
-  # Person.new 'username', {:fast_hash => true}
+  # Rlaunchpadlib::ProjectGroup.new 'group', {:fast_hash => true}
   class ProjectGroup
 
         include HTTParty

--- a/lib/rlaunchpadlib/project_group.rb
+++ b/lib/rlaunchpadlib/project_group.rb
@@ -1,24 +1,30 @@
 require 'httparty'
 
 module Rlaunchpadlib
-    class ProjectGroup
+  # 
+  # bewitchingme: Added an option to ensure the resulting hash uses symbols for keys;
+  # default behavior remains the same.
+  # 
+  # Person.new 'username', {:fast_hash => true}
+  class ProjectGroup
 
         include HTTParty
 
         attr_accessor :group
         attr_accessor :overview_data
+        attr_accessor :opts
 
-        def initialize(group)
-            @group = group
-            @client = Rlaunchpadlib::Client.new
+        def initialize(group, options = {})
+          @opts = options
+          @group = group
+          @client = Rlaunchpadlib::Client.new @opts
         end
 
         def overview
-             if @overview_data.nil?
-                @client.get(@group)
-            else
-                @overview_data
+            if @overview_data.nil?
+                @overview_data = @client.get(@group)
             end
+            @overview_data
         end
 
         def bugs
@@ -35,7 +41,8 @@ module Rlaunchpadlib
 
         # I'm nuts so lets patch method missing.
         def method_missing(name, *args, &block)
-          overview.has_key?(name.to_s) ? overview[name.to_s] : super
+          key = @opts[:fast_hash] ? name : name.to_s
+          overview.has_key?(key) ? overview[key] : super
         end
 
 

--- a/lib/rlaunchpadlib/version.rb
+++ b/lib/rlaunchpadlib/version.rb
@@ -1,3 +1,3 @@
 module Rlaunchpadlib
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/rlaunchpadlib/lib/client_spec.rb
+++ b/spec/rlaunchpadlib/lib/client_spec.rb
@@ -14,6 +14,7 @@ describe 'Rlaunchpadlib::Client' do
 
         before(:each) do
             @client = Rlaunchpadlib::Client.new
+            @clientfh = Rlaunchpadlib::Client.new({:fast_hash => true})
         end
 
         it "on a basic resource returns a Hash Result" do
@@ -24,5 +25,15 @@ describe 'Rlaunchpadlib::Client' do
            expect(@client.get('charms', 'getTasks')).to be_a(Hash) 
         end
 
+        # These two tests could be beefed up to determine if the deeply-nested keys are symbols
+        # but this test should suffice as the same operation is performed for each level.
+        it "on a basic resource returns a Hash Result with symbolic keys [:fast_hash set to true]" do
+          expect(@clientfh.get('~lazypower').keys[0]).to be_a(Symbol)
+        end
+        
+        it "on a sub-resource returns a Hash Result with symbolic keys [:fast_hash set to true]" do
+          expect(@clientfh.get('charms', 'getTasks').keys[0]).to be_a(Symbol)
+        end
+        
     end
 end


### PR DESCRIPTION
Depending on the number of objects you're dealing with with respect to 'bugs', you may want to set :fast_hash to true for quicker lookups on iterations.  Accessing the members through method_missing is still honored.  Updated the README.md and added a test.
